### PR TITLE
feat(agg_players): Keep the date_time for abandoned players

### DIFF
--- a/apps/collector/lib/collector/agg_players/agg_players.ex
+++ b/apps/collector/lib/collector/agg_players/agg_players.ex
@@ -142,7 +142,7 @@ defmodule Collector.AggPlayers do
     prev_increments =
       for x <- prev_agg_players,
           x.player_id in abandoned_players,
-          do: Map.put(x, :target_dt, target_dt)
+          do: x
 
     new_increments ++ prev_increments
   end

--- a/apps/collector/test/agg_players_test.exs
+++ b/apps/collector/test/agg_players_test.exs
@@ -722,7 +722,7 @@ defmodule Collector.AggPlayersTest do
     [p1, p2] = Enum.sort_by(agg_players, & &1.player_id)
 
     assert(length(p1.increment) == 1)
-    assert(Date.compare(DateTime.to_date(p1.target_dt), target_date) == :eq)
+    assert(Date.compare(DateTime.to_date(p1.target_dt), target_date) == :lt)
     assert(length(p2.increment) == 2)
   end
 


### PR DESCRIPTION
Actually, update the date_time is a non sense. Now, if we want to consult the last activity, we need to go the the increments, in this way we can just check the :target_dt field